### PR TITLE
Broaden plugin manifests + CONTRIBUTING to match new positioning

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "gtm-cofounder",
       "source": "./",
-      "description": "Go-to-market Agent Skills for technical AI/dev-tool founders, the GTM co-founder you don't have. Positioning, ICP, homepage, launch, pricing, distribution. Grounded in Adam Frankl and Jakub Czakon."
+      "description": "Go-to-market Agent Skills for developer tools and AI products, the GTM co-founder you don't have. For founders, early GTM hires, and founding AEs. Positioning, ICP, homepage, launch, pricing, distribution. Grounded in Adam Frankl and Jakub Czakon."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gtm-cofounder",
   "version": "1.3.0",
-  "description": "The GTM co-founder you don't have, go-to-market Agent Skills for technical AI/dev-tool founders building alone. Grounded in Adam Frankl and Jakub Czakon.",
+  "description": "The GTM co-founder you don't have, go-to-market Agent Skills for developer tools and AI products. For founders, early GTM hires, and founding AEs. Grounded in Adam Frankl and Jakub Czakon.",
   "author": {
     "name": "Shane O'Connor",
     "url": "https://thedevtoolgtmcompany.com"
@@ -12,8 +12,11 @@
     "gtm",
     "go-to-market",
     "dev-tools",
+    "ai-products",
     "ai-founders",
     "technical-founders",
+    "gtm-hire",
+    "founding-ae",
     "positioning",
     "developer-marketing",
     "agent-skills",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-This is a living toolkit for technical founders. Contributions that make it sharper are welcome.
+This is a living toolkit for the people who take developer tools and AI products to market: founders, early GTM hires, and founding AEs. Contributions that make it sharper are welcome.
 
 ## What makes a good contribution
 
@@ -21,4 +21,4 @@ This is a living toolkit for technical founders. Contributions that make it shar
 
 - Generic "growth hacking" tactics, engagement-bait, or anything that tricks developers. The first rule of dev GTM is: don't lie to developers. They find out.
 
-Thanks for helping technical founders get out of their own way.
+Thanks for helping founders, GTM hires, and founding AEs get out of their own way.


### PR DESCRIPTION
Follows the README broadening (#6). Updates the remaining repo metadata so the plugin marketplace listing and contributor docs match the wider audience and scope.

- `plugin.json` / `marketplace.json` descriptions: "technical AI/dev-tool founders" -> "developer tools and AI products. For founders, early GTM hires, and founding AEs."
- Added keywords: `ai-products`, `gtm-hire`, `founding-ae` (kept existing).
- `CONTRIBUTING.md`: same broadening in the two audience lines.

Not touched here (needs your call, flagged separately): `AGENTS.md` audience framing (your emotional-core voice) and the 18 skill frontmatter descriptions that say "the founder".

🤖 Generated with [Claude Code](https://claude.com/claude-code)