### PR TITLE
Add 18-devrel-and-community skill (grounded in swyx's Learn in Public)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Then the **roadmap**: the agent turns that brief into an honest diagnosis and a 
 | Skill | Reach for it when… |
 |-------|--------------------|
 | **founder-led-content** | "Marketing" feels gross, so you do none, while your competitor owns the conversation |
+| **devrel-and-community** | You know you should "do community" or "need DevRel," but it feels vague or premature, or you are about to spin up a Discord nobody shows up to |
 | **know-if-its-working** | You have dashboards full of vanity metrics and no idea whether GTM is actually working |
 | **market-scan** | A rival just rebranded or a new tool appeared, and your positioning is answering last year's market |
 

--- a/skills/18-devrel-and-community/SKILL.md
+++ b/skills/18-devrel-and-community/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: devrel-and-community
+description: Build developer trust at scale through developer relations and community, without a DevRel hire and without a ghost-town Discord. Covers the founder-as-advocate, "learn in public" as a compounding content and distribution engine, when a community is actually ready (and when it is a vanity project), and how to make it a loop instead of a broadcast. Grounded in the work of Shawn Wang (swyx). Use when the founder knows they should "do community" or "do DevRel" but it feels vague, performative, or premature.
+---
+
+# DevRel and community (trust that compounds)
+
+> Developers don't adopt because you reached them. They adopt because they trust you, and trust compounds when you build and teach in the open. DevRel and community are not a hire you make later. Early on, you are the advocate, and the cheapest, most durable engine you have is to learn in public.
+
+**Use this when:** a founder feels they "should be doing community" or "need DevRel," but it is vague, feels like marketing theatre, or they are about to spin up a Discord nobody will show up to.
+
+## The core idea
+
+For a developer tool, your distribution is trust, and trust is earned by being genuinely useful in public over time. That is what developer relations is, stripped of the job title: teaching the problem space, showing your work, and being present in the rooms your developers already live in. You do not need a DevRel hire to start. You need to start. This reads your `docs/gtm-cofounder/founder-brief.md` so the rooms, the topics, and the ICP are yours, not generic.
+
+## The engine: learn in public (swyx)
+
+The single highest-leverage habit here comes from Shawn Wang's "Learn in Public." The idea: instead of learning privately and occasionally "doing marketing," you **document what you are building and learning, in public, as you go.** Every post, thread, or demo is a small lure that keeps working after you publish it, and they compound into a body of work, a reputation, and inbound.
+
+How a founder runs it:
+- **Document, don't create.** You are not writing think-pieces. You are sharing what you just figured out, the bug you fixed, the design decision you made, the thing that surprised you. That is content you were going to produce anyway.
+- **Make the thing you wish existed.** The best content is the guide you needed and could not find. Write that.
+- **Ship small and consistent.** A steady drip of useful, specific posts beats one big launch essay. Consistency is the whole game.
+- **Pick up what they put down.** Engage with other people's work in your space, genuinely. Reputation is a two-way street.
+- **It is a lure, not a broadcast.** You are not shouting your product. You are being useful about the problem, and the product follows.
+
+## Founder as the first advocate
+
+Before you hire DevRel, you are DevRel. That means:
+- **Teach the problem space, not the product.** Be the person who explains the thing developers are struggling with. The tool earns the right to come up later.
+- **Be in the rooms, as a peer.** The specific places your ICP already is (from `first-50-users`): the relevant Slacks, Discords, subreddits, HN, the OSS communities. Contribute value, do not drop links.
+- **Answer everything, in public.** Every good answer to a real question is evergreen advocacy.
+
+## Community: when it is actually time
+
+A community too early is the saddest thing in dev tools: a ghost Discord that signals "nobody is here." Decide honestly:
+
+```
+Do you have enough users who feel the same pain to gather, and a reason for them to talk to each other (not just to you)?
+├─ NO  → not yet. Keep learning in public and doing 1:1 support. A community needs members with something in common. Manufacturing one early backfires.
+└─ YES → start small and seeded. Make it a loop, not a broadcast (below).
+```
+
+If you do start one, make it a loop, not a mailing list:
+- **Give a reason to show up that is not you.** Members should get value from each other: answers, patterns, work-in-progress, jobs. If the only value is you posting updates, it is a newsletter with extra steps.
+- **Seed it deliberately.** Bring the first 10 to 20 real users in by hand, spark the first conversations, and answer fast. Empty rooms stay empty.
+- **Spotlight members, not the product.** Celebrate what people build with you. A community is a movement around a shared problem, not a fan club for your changelog.
+- **The founder shows up.** Early, your presence is the reason it has energy. You cannot fully delegate this yet.
+
+## The loop (why this compounds)
+
+Learn in public attracts developers. Some become users. Some users become community. The community creates its own content and advocacy (answers, demos, posts), which attracts more developers. That is a real growth loop, not a channel you rent. It is slow to start and very hard to kill once it turns.
+
+## The metrics that matter (not vanity)
+
+- Not followers or member counts. Those are ghost-town-compatible.
+- **Inbound from the right people:** replies, DMs, and sign-ups from your actual ICP, traceable to something you published.
+- **Content that keeps pulling:** posts that still bring people months later.
+- **Members who bring members:** the community growing without you dragging each person in.
+
+## Mistakes that look reasonable
+
+- **A community before you have a crowd.** An empty Discord actively signals failure. Wait until there are people with a shared reason to gather.
+- **Learn-in-public as humblebrag.** If it reads as marketing or flex, it fails. The bar is genuinely useful and specific.
+- **DevRel as broadcast.** Posting *at* developers instead of being useful *with* them. They can tell instantly.
+- **Outsourcing your voice too early.** Hiring DevRel to replace the founder before the founder has found the voice. You cannot delegate a voice that does not exist yet.
+- **Chasing follower counts.** Reach without trust does nothing. Correct association beats raw awareness.
+
+## When to make your first DevRel hire
+
+Not until the founder-led motion is working and the bottleneck is genuinely the founder's time. Hire someone who is a developer first and can be authentically useful, not a marketer who will broadcast. The role scales the founder's voice; it does not invent it.
+
+## Feeds the brief
+
+Log which topics and rooms actually pull your ICP, and which posts keep bringing people, so your public output gets sharper over time instead of scattered.
+
+## Your next 30 minutes
+
+- [ ] Pick one thing you learned or decided this week and publish it, specific and useful, today.
+- [ ] Go be genuinely helpful in one room your developers already live in. No links.
+- [ ] Decide honestly: do you have a crowd to gather yet, or is it still too early for a community?
+
+---
+Part of the GTM Co-Founder skills. This one is grounded in the work of **Shawn Wang (swyx)**, especially [Learn in Public](https://www.swyx.io/learn-in-public). Built from real dev-tool GTM experience, with frameworks from Adam Frankl and Jakub Czakon. When a framework can't make the call, that's what a human is for.


### PR DESCRIPTION
Adds `18-devrel-and-community`, a new skill on developer relations and community for dev-tool founders.

**Why:** the pack covers strategy, story, channels, and sales, but has nothing on DevRel or community, one of the biggest levers for developer trust.

**What it covers**
- The founder as the first advocate (teach the problem, not the product)
- "Learn in public" as a compounding content and distribution engine
- A decision tree for when a community is actually ready (and the ghost-Discord trap)
- Making a community a loop, not a broadcast
- The metrics that matter (not follower counts), and when to make the first DevRel hire

**Grounding:** built on the work of **Shawn Wang (swyx)**, especially [Learn in Public](https://www.swyx.io/learn-in-public), credited in the skill footer, consistent with how the pack credits Frankl and Czakon.

Also adds a README row under section 4 (Keep it going). Numbered `18` to avoid renumbering existing skills; easy to reposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)